### PR TITLE
When installing, cp should quote file paths

### DIFF
--- a/src/PythonBridge-Pharo/PBPharoPlatform.class.st
+++ b/src/PythonBridge-Pharo/PBPharoPlatform.class.st
@@ -48,10 +48,11 @@ PBPharoPlatform >> copyApplicationTo: appFolder application: application [
 	"Copy the runtime directory"
 	cpCommand := String streamContents: [ :stream |
 		stream
-			<< 'cp -a ';
+			<< 'cp -a "';
 			<< srcDir fullName;
-			<< ' ';
-			<< appFolder fullName ].
+			<< '" "';
+			<< appFolder fullName;
+			<< '"' ].
 	proc := OSSUnixSubprocess new 
 		shellCommand: cpCommand;
 		runAndWait.


### PR DESCRIPTION
Currently fails if paths contain spaces