### PR TITLE
Fix sending trimBoth to a file reference instance in Windows case on resolvePipenvPath method

### DIFF
--- a/src/PythonBridge-Pharo/PBPharoPipenvPathFinder.class.st
+++ b/src/PythonBridge-Pharo/PBPharoPipenvPathFinder.class.st
@@ -53,7 +53,7 @@ PBPharoPipenvPathFinder class >> resolvePipenvPath [
 					thenSelect: [ :each | #(bat exe) includes: each extension asLowercase ].
 			path := lines
 				ifEmpty: [ ^ self signalPipenvNotFound ]
-				ifNotEmpty: [ :anArray | anArray first trimBoth ] ].
+				ifNotEmpty: [ :anArray | anArray first fullName trimBoth] ].
 	path ifEmpty: [ ^ self signalPipenvNotFound ].
 	^ path asFileReference
 ]


### PR DESCRIPTION
In the `resolvePipenvPath` method of the `PBPharoPipenvPathFinder` class, there is a special case executed when on Windows. There, the `lines` variable is an array of file references. In the case that this array is not empty, get the first element (a file reference) and send `trimBoth` to it. This raises an exception, since `FileReference` has not `trimBoth` method. I just convert the file reference object to string using `fullName`. Then, `trimBoth` works. 