### PR TITLE
fix gtTrace for zero-argument functions

### DIFF
--- a/PyPI/src/gtoolkit_bridge/PythonBridge/telemetry.py
+++ b/PyPI/src/gtoolkit_bridge/PythonBridge/telemetry.py
@@ -73,7 +73,7 @@ def gtTrace(func):
         funcName = func.__name__
         funcArgNames = inspect.getfullargspec(func).args
         funcArgs = [(name, copy(value)) for name, value in zip(funcArgNames, args)]
-        if (funcArgNames[0] == 'self'):
+        if (len(funcArgNames) > 0 and funcArgNames[0] == 'self'):
             receiver = args[0]
             funcArgs = funcArgs[1:]
         else:


### PR DESCRIPTION
gtTrace checks the name of a method's first argument in order to determine whether it's 'self' (which is customarily used in object methods). It does however not check whether there are any arguments at all, causing gtTrace to fail for standalone functions without any arguments.

This fix adds a check on whether there are any arguments before accessing the name of the first argument.